### PR TITLE
docs: without apidoc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,4 +65,8 @@ repos:
         name: Check version numbers
         entry: python ./.github/check_version.py
         language: system
-        files: '^(setup.json)|(aiida_sssp_workflow/__init__.py)'
+        files: >-
+            (?x)^(
+                setup.json|
+                aiida_sssp_workflow/__init__.py|
+            )$

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,0 @@
-version: 2
-
-python:
-  version: 3.7
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,14 +15,10 @@ import os
 import sys
 import time
 
-import aiida_sssp_workflow
-from aiida.manage.configuration import load_documentation_profile
-
 # -- AiiDA-related setup --------------------------------------------------
 
 # Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current
 # default profile of the AiiDA installation does not use a Django backend.
-load_documentation_profile()
 
 # If we are not on READTHEDOCS load the Sphinx theme manually
 if not os.environ.get('READTHEDOCS', None):
@@ -82,7 +78,7 @@ copyright = f'{copyright_year_string}, {copyright_owners}. All rights reserved'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = aiida_sssp_workflow.__version__
+release = '0.1.0b'
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 
@@ -93,28 +89,6 @@ version = '.'.join(release.split('.')[:2])
 # Usually you set "language" from the command line for these cases.
 language = None
 
-# There are two options for replacing |today|: either, you set today to some
-# non-false value, then it is used:
-#today = ''
-# Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# exclude_patterns = ['doc.rst']
-#~ exclude_patterns = ['index.rst']
-
-# The reST default role (used for this markup: `text`) to use for all
-# documents.
-#default_role = None
-
-# If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
-
-# If true, the current module name will be prepended to all description
-# unit titles (such as .. function::).
-#add_module_names = True
-
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
 show_authors = True
@@ -122,78 +96,10 @@ show_authors = True
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
-# A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
-
-# If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
-
-# -- Options for HTML output ----------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#~ html_theme = 'basicstrap'
-## SET BELOW
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
     'display_version': True,
 }
-
-# Add any paths that contain custom themes here, relative to this directory.
-#~ html_theme_path = ["."]
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-#html_title = None
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
-
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-# html_logo = "images/.png"
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-# html_favicon = "images/favicon.ico"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
-
-# Add any extra paths that contain custom files (such as robots.txt or
-# .htaccess) here, relative to this directory. These files are copied
-# directly to the root of the documentation.
-#html_extra_path = []
-
-# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
-# using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
-
-# Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
-
-# Additional templates that should be rendered to pages, maps page names to
-# template names.
-#html_additional_pages = {}
-
-# If false, no module index is generated.
-#html_domain_indices = True
-
-# If false, no index is generated.
-#html_use_index = True
-
-# If true, the index is split into individual pages for each letter.
-#html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
@@ -245,110 +151,7 @@ latex_elements = {
     #'figure_align': 'htbp',
 }
 
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-# latex_documents = [
-# ]
-
-# The name of an image file (relative to this directory) to place at the top of
-# the title page.
-#latex_logo = None
-
-# For "manual" documents, if this is true, then toplevel headings are parts,
-# not chapters.
-#latex_use_parts = False
-
-# If true, show page references after internal links.
-#latex_show_pagerefs = False
-
-# If true, show URL addresses after external links.
-#latex_show_urls = False
-
-# Documents to append as an appendix to all manuals.
-#latex_appendices = []
-
-# If false, no module index is generated.
-#latex_domain_indices = True
-
 # autodoc mock
 autodoc_mock_imports = ['f90wrap', 'sssp.efermi_module', 'numpy']
 
-
-def run_apidoc(_):
-    """Runs sphinx-apidoc when building the documentation.
-
-    Needs to be done in conf.py in order to include the APIdoc in the
-    build on readthedocs.
-
-    See also https://github.com/rtfd/readthedocs.org/issues/1139
-    """
-    source_dir = os.path.abspath(os.path.dirname(__file__))
-    apidoc_dir = os.path.join(source_dir, 'apidoc')
-    package_dir = os.path.join(source_dir, os.pardir, os.pardir,
-                               'aiida_sssp_workflow')
-
-    # In #1139, they suggest the route below, but this ended up
-    # calling sphinx-build, not sphinx-apidoc
-    #from sphinx.apidoc import main
-    #main([None, '-e', '-o', apidoc_dir, package_dir, '--force'])
-
-    import subprocess
-    cmd_path = 'sphinx-apidoc'
-    if hasattr(sys, 'real_prefix'):  # Check to see if we are in a virtualenv
-        # If we are, assemble the path manually
-        cmd_path = os.path.abspath(
-            os.path.join(sys.prefix, 'bin', 'sphinx-apidoc'))
-
-    options = [
-        '-o',
-        apidoc_dir,
-        package_dir,
-        '--private',
-        '--force',
-        '--no-toc',
-    ]
-
-    # See https://stackoverflow.com/a/30144019
-    env = os.environ.copy()
-    env['SPHINX_APIDOC_OPTIONS'] = 'members,special-members,private-members,undoc-members,show-inheritance'
-    subprocess.check_call([cmd_path] + options, env=env)
-
-
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
-
-
-# -- Options for manual page output ---------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-# man_pages = [
-# ]
-
-# If true, show URL addresses after external links.
-#man_show_urls = False
-
-# -- Options for Texinfo output -------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-# texinfo_documents = [
-# ]
-
-# Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
-
-# If false, no module index is generated.
-#texinfo_domain_indices = True
-
-# How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
-
-# If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
-
-# Warnings to ignore when using the -n (nitpicky) option
-# We should ignore any python built-in exception, for instance
 nitpick_ignore = []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,7 +13,6 @@ The aiida-sssp-workflow plugin for `AiiDA`_
 
    user_guide/index
    developer_guide/index
-   API documentation <apidoc/aiida_sssp_workflow>
 
 If you use this plugin for your research, please cite the following work:
 
@@ -23,7 +22,7 @@ If you use this plugin for your research, please cite the following work:
 
 .. highlights:: K. Lejaeghere et al., Science 351 (6280), 1415 (2016).
   http://molmod.ugent.be/deltacodesdft
-http://molmod.ugent.be/deltacodesdft
+
 If you use AiiDA for your research, please cite the following work:
 
 .. highlights:: Giovanni Pizzi, Andrea Cepellotti, Riccardo Sabatini, Nicola Marzari,


### PR DESCRIPTION
Turn off installing of the package when deploying docs in readthedocs, since the package requires FORTRAN compiler to install it, while readthedocs image does not have Fortran compiler. 
The docs compiled like here: https://aiida-sssp-workflow-jason.readthedocs.io/en/doc-test/