### PR TITLE
⏱  ph calculation increase walltime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # aiida-sssp-workflow
 
+## Resource options and parallelzation
+
+### Walltime settings
+
+The max wallclock seconds are set from the `options` input parameters from verification workflow.
+This option will then pass to all the inside pw and ph calculation process as the `metadata.options` setting.
+The `options` dict has the format of:
+
+```python
+{
+    "resources": {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 32,
+    },
+    "max_wallclock_seconds": 1800,  # 30 min
+    "withmpi": True,
+}
+
+```
+where the `max_wallclock_seconds` is exactly used for pw calculation while for ph calculation the value is set to 4 time of value since the ph calculation roughly estimated to elapse 4 times slower that pw calculation of the corresponding pw calculation to finish.
+
+
 ## Configurations
 
 Different verifications use different structure configurations.

--- a/aiida_sssp_workflow/workflows/evaluate/_phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_phonon_frequencies.py
@@ -170,6 +170,12 @@ class PhononFrequenciesWorkChain(WorkChain):
             cmdline_list.append(f"-{str(key)}")
             cmdline_list.append(str(value))
 
+        # Sinec PH calculation always runs more time then the correspoding pw calculation
+        # set the walltime to 4 times as set in option.
+        pw_max_walltime = self.ctx.options.get("max_wallclock_seconds", None)
+        if pw_max_walltime:
+            self.ctx.options["max_wallclock_seconds"] = pw_max_walltime * 4
+
         inputs = {
             "metadata": {"call_link_label": "PH"},
             "ph": {


### PR DESCRIPTION
Ph calculation in phonon frequencies convergenece verification always
cost more times than corresponting pw calculation which lead to ph
calculation reach the walltime everytime where the walltime setting for
pw calculation is enough to finish (another important reason is that
before aiida-2.0 the scheduler walltime did not detect the walltime
properly
https://github.com/aiidateam/aiida-core/commit/bab1ad6cfc8e4ff041bce268f9270c613663cb35).