### PR TITLE
Fix: class variable all move to ctx

### DIFF
--- a/aiida_sssp_workflow/workflows/convergence/_base.py
+++ b/aiida_sssp_workflow/workflows/convergence/_base.py
@@ -111,8 +111,8 @@ class BaseLegacyWorkChain(WorkChain):
         from pseudo_parser.upf_parser import parse_element, parse_pseudo_type
 
         cutoff_control = get_protocol(category='control', name=self.inputs.cutoff_control.value)
-        self._ECUTWFC_LIST = cutoff_control['wfc_scan']
-        self._REFERENCE_ECUTWFC = self._ECUTWFC_LIST[-1]    # use the last cutoff as reference
+        self.ctx.ecutwfc_list = self._ECUTWFC_LIST = cutoff_control['wfc_scan']
+        self.ctx.reference_ecutwfc = self._ECUTWFC_LIST[-1]    # use the last cutoff as reference
 
         self.ctx.extra_pw_parameters = {}
         content = self.inputs.pseudo.get_content()
@@ -278,7 +278,7 @@ class BaseLegacyWorkChain(WorkChain):
         """
         run on reference calculation
         """
-        ecutwfc = self._REFERENCE_ECUTWFC
+        ecutwfc = self.ctx.reference_ecutwfc
         ecutrho = ecutwfc * self.ctx.dual
         inputs = self._get_inputs(ecutwfc=ecutwfc, ecutrho=ecutrho)
 
@@ -304,9 +304,9 @@ class BaseLegacyWorkChain(WorkChain):
         """
         run on all other evaluation sample points
         """
-        self.ctx.max_ecutrho = ecutrho = self._REFERENCE_ECUTWFC * self.ctx.dual
+        self.ctx.max_ecutrho = ecutrho = self.ctx.reference_ecutwfc * self.ctx.dual
 
-        for ecutwfc in self._ECUTWFC_LIST[:-1]: # The last one is reference
+        for ecutwfc in self.ctx.ecutwfc_list[:-1]: # The last one is reference
             inputs = self._get_inputs(ecutwfc=ecutwfc, ecutrho=ecutrho)
 
             running = self.submit(self._EVALUATE_WORKCHAIN, **inputs)

--- a/aiida_sssp_workflow/workflows/convergence/_base.py
+++ b/aiida_sssp_workflow/workflows/convergence/_base.py
@@ -44,8 +44,6 @@ class BaseLegacyWorkChain(WorkChain):
     # pylint: disable=too-many-instance-attributes
     __metaclass__ = ABCMeta
 
-    _MAX_WALLCLOCK_SECONDS = 1800 * 3
-
     _PROPERTY_NAME = abstract_attribute()   # used to get convergence protocol
     _EVALUATE_WORKCHAIN = abstract_attribute()
     _MEASURE_OUT_PROPERTY = abstract_attribute()
@@ -261,9 +259,7 @@ class BaseLegacyWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS,
-                with_mpi=True)
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if 'parallelization' in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -136,7 +136,7 @@ class ConvergencePressureWorkChain(BaseLegacyWorkChain):
         # for it which need to be run before the following step.
 
         # This workflow is shared with delta factor workchain for birch murnagan fitting.
-        ecutwfc = self._REFERENCE_ECUTWFC
+        ecutwfc = self.ctx.reference_ecutwfc
         ecutrho = ecutwfc * self.ctx.dual
         parameters = {
             'SYSTEM': {

--- a/aiida_sssp_workflow/workflows/evaluate/_bands.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_bands.py
@@ -173,9 +173,7 @@ class BandsWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/evaluate/_cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_cohesive_energy.py
@@ -42,8 +42,6 @@ def create_isolate_atom(
 class CohesiveEnergyWorkChain(WorkChain):
     """WorkChain to calculate cohisive energy of input structure"""
 
-    _MAX_WALLCLOCK_SECONDS = 3600
-
     @classmethod
     def define(cls, spec):
         """Define the process specification."""
@@ -139,9 +137,7 @@ class CohesiveEnergyWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/evaluate/_delta.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_delta.py
@@ -16,8 +16,6 @@ UpfData = DataFactory("pseudo.upf")
 class DeltaWorkChain(WorkChain):
     """WorkChain calculate the bands for certain pseudopotential"""
 
-    _MAX_WALLCLOCK_SECONDS = 3600
-
     @classmethod
     def define(cls, spec):
         """Define the process specification."""
@@ -98,9 +96,7 @@ class DeltaWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/evaluate/_phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_phonon_frequencies.py
@@ -17,8 +17,6 @@ UpfData = DataFactory("pseudo.upf")
 class PhononFrequenciesWorkChain(WorkChain):
     """WorkChain to calculate cohisive energy of input structure"""
 
-    _MAX_WALLCLOCK_SECONDS = 3600
-
     @classmethod
     def define(cls, spec):
         """Define the process specification."""
@@ -107,9 +105,7 @@ class PhononFrequenciesWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/evaluate/_pressure.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_pressure.py
@@ -34,8 +34,6 @@ def helper_get_hydrostatic_stress(output_trajectory, output_parameters):
 class PressureWorkChain(WorkChain):
     """WorkChain to calculate cohisive energy of input structure"""
 
-    _MAX_WALLCLOCK_SECONDS = 3600
-
     @classmethod
     def define(cls, spec):
         """Define the process specification."""
@@ -103,9 +101,7 @@ class PressureWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/measure/bands.py
+++ b/aiida_sssp_workflow/workflows/measure/bands.py
@@ -106,7 +106,6 @@ class BandsMeasureWorkChain(WorkChain):
     WorkChain to run bands measure,
     run without sym for distance compare and band structure along the path
     """
-    _MAX_WALLCLOCK_SECONDS = 1800 * 3
     _RY_TO_EV = 13.6056980659
 
     @classmethod
@@ -245,9 +244,7 @@ class BandsMeasureWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/measure/delta.py
+++ b/aiida_sssp_workflow/workflows/measure/delta.py
@@ -18,7 +18,6 @@ class DeltaMeasureWorkChain(WorkChain):
 
     # pylint: disable=too-many-instance-attributes
 
-    _MAX_WALLCLOCK_SECONDS = 1800 * 3
     _OXIDE_STRUCTURES = ["XO", "XO2", "XO3", "X2O", "X2O3", "X2O5"]
     _UNARIE_STRUCTURES = ["BCC", "FCC", "SC", "Diamond"]
 
@@ -151,9 +150,7 @@ class DeltaMeasureWorkChain(WorkChain):
         else:
             from aiida_sssp_workflow.utils import get_default_options
 
-            self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
-            )
+            self.ctx.options = get_default_options(with_mpi=True)
 
         if "parallelization" in self.inputs:
             self.ctx.parallelization = self.inputs.parallelization.get_dict()

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -53,8 +53,6 @@ DEFAULT_PROPERTIES_LIST = [
 class VerificationWorkChain(WorkChain):
     """The verification workflow to run all test for the given pseudopotential"""
 
-    _MAX_WALLCLOCK_SECONDS = 1800 * 3
-
     @classmethod
     def define(cls, spec):
         super().define(spec)
@@ -130,7 +128,7 @@ class VerificationWorkChain(WorkChain):
             from aiida_sssp_workflow.utils import get_default_options
 
             self.ctx.options = get_default_options(
-                max_wallclock_seconds=self._MAX_WALLCLOCK_SECONDS, with_mpi=True
+                with_mpi=True,
             )
 
         if "parallelization" in self.inputs:


### PR DESCRIPTION
fixes #89 

Some class variables such as self._REFERENCE_ECUTWFC in _base convergence work chain is not stored in the `ctx` of work chain. It is fine if the daemon is not restarted but leads to a problem that the class lost this variable when the daemon restart. Since the variable is not set with the class but in the step.

To resolve this, all the variables that pass to other work chain steps need to be stored as `ctx`.

- also remave all `_MAX_WALLTIME` class attributes.
