### PR TITLE
Not run oxides delta measure on oxygen

### DIFF
--- a/aiida_sssp_workflow/workflows/measure/delta.py
+++ b/aiida_sssp_workflow/workflows/measure/delta.py
@@ -97,7 +97,13 @@ class DeltaMeasureWorkChain(WorkChain):
         # keys here are: BCC, FCC, SC, Diamond, XO, XO2, XO3, X2O, X2O3, X2O5
         # parentatheses means not supported yet.
         self.ctx.structures = {}
-        for configuration in self._OXIDE_STRUCTURES + self._UNARIE_STRUCTURES:
+        if self.ctx.element == "O":
+            # For oxygen, only unaries are available.
+            configuration_list = self._UNARIE_STRUCTURES
+        else:
+            configuration_list = self._OXIDE_STRUCTURES + self._UNARIE_STRUCTURES
+
+        for configuration in configuration_list:
             self.ctx.structures[configuration] = get_standard_structure(
                 element,
                 prop="delta",

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -26,9 +26,9 @@ def run_verification(pw_code, ph_code, upf):
         "cutoff_control": orm.Str("test"),
         "properties_list": orm.List(
             list=[
-                # "accuracy:delta",
+                "accuracy:delta",
                 # "accuracy:bands",
-                "convergence:cohesive_energy",
+                # "convergence:cohesive_energy",
                 # "convergence:phonon_frequencies",
                 # "convergence:pressure",
                 # "convergence:delta",


### PR DESCRIPTION
fixes #88 

The oxides configurations are not available for oxygen. However, the delta measures check on them which leads to the structure not finding issues. 