### PR TITLE
Able to set wavefunction cutoff and skip to rho test only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # aiida-sssp-workflow
 
+## Logic of convergence test on different criteria protocol
+
+The wavefunction cutoff scan list are same no matter which criteria protocol is used.
+Therefore, the running of wavefunction cutoff test write wavefunction cutoff recommendation for all criteria protocol.
+When switching to other criteria protocol, the wavefunction cutoff test can be skipped by setting `preset_ecutwfc`. It will then be used and only run charge density cutoff test.
+
 ## Lanthanides
 
 For lanthanides the delta measure is run on nitrides as Wentzcovitch paper and on oxides.

--- a/aiida_sssp_workflow/utils.py
+++ b/aiida_sssp_workflow/utils.py
@@ -13,8 +13,9 @@ from aiida.plugins import DataFactory
 UpfData = DataFactory("pseudo.upf")
 
 
-def get_protocol(category, name):
-    """Load and read protocol from faml file to a verbose dict"""
+def get_protocol(category, name=None):
+    """Load and read protocol from faml file to a verbose dict
+    if name not set, return whole protocol."""
     import_path = importlib.resources.path(
         "aiida_sssp_workflow.protocol", f"{category}.yml"
     )
@@ -23,7 +24,10 @@ def get_protocol(category, name):
             handle
         )  # pylint: disable=attribute-defined-outside-init
 
-    return protocol_dict[name]
+    if name:
+        return protocol_dict[name]
+    else:
+        return protocol_dict
 
 
 RARE_EARTH_ELEMENTS = [

--- a/aiida_sssp_workflow/workflows/convergence/_base.py
+++ b/aiida_sssp_workflow/workflows/convergence/_base.py
@@ -70,6 +70,8 @@ class BaseConvergenceWorkChain(SelfCleanWorkChain):
                     help='The cutoff control list to use for the workchain.')
         spec.input('criteria', valid_type=orm.Str, required=True,
                     help='Criteria for convergence measurement to give recommend cutoff pair.')
+        spec.input('preset_ecutwfc', valid_type=orm.Int, required=False,
+                    help='Preset wavefunction cutoff will be used and skip wavefunction test.')
         spec.input('options', valid_type=orm.Dict, required=False,
                     help='Optional `options`.')
         spec.input('parallelization', valid_type=orm.Dict, required=False,
@@ -156,8 +158,18 @@ class BaseConvergenceWorkChain(SelfCleanWorkChain):
     def _is_run_wfc_convergence_test(self):
         """If running wavefunction convergence test
         default True, override class attribute `_RUN_WFC_TEST`
-        in subclass to supress running it"""
-        return self._RUN_WFC_TEST
+        in subclass to supress running it
+
+        If 'preset_ecutwfc' is set in inputs will use that value and
+        skip the wavefunction cutoff test.
+        """
+        if 'preset_ecutwfc' in self.inputs:
+            self.ctx.wfc_cutoff = self.inputs.preset_ecutwfc.value
+            assert self.ctx.wfc_cutoff < self.ctx.reference_ecutwfc
+
+            return False
+        else:
+            return self._RUN_WFC_TEST
 
     def _is_run_rho_convergence_test(self):
         """If running charge density convergence test
@@ -321,6 +333,8 @@ class BaseConvergenceWorkChain(SelfCleanWorkChain):
         ecutrho = ecutwfc * self.ctx.dual
         inputs = self._get_inputs(ecutwfc=round(ecutwfc), ecutrho=round(ecutrho))
 
+        self.ctx.max_ecutrho = self.ctx.reference_ecutwfc * self.ctx.dual
+
         running = self.submit(self._EVALUATE_WORKCHAIN, **inputs)
         self.report(f'launching reference calculation: {running.process_label}<{running.pk}>')
 
@@ -342,8 +356,6 @@ class BaseConvergenceWorkChain(SelfCleanWorkChain):
         """
         run on all other evaluation sample points
         """
-        self.ctx.max_ecutrho = self.ctx.reference_ecutwfc * self.ctx.dual
-
         for ecutwfc in self.ctx.ecutwfc_list[:-1]: # The last one is reference
             ecutrho = ecutwfc * self.ctx.dual
             ecutwfc, ecutrho = round(ecutwfc), round(ecutrho)
@@ -458,8 +470,9 @@ class BaseConvergenceWorkChain(SelfCleanWorkChain):
         ecutwfc = self.ctx.wfc_cutoff
         # Only run rho test when ecutrho less than the max reference
         # otherwise meaningless for the exceeding cutoff test
-        for ecutrho in [dual * ecutwfc for dual in self.ctx.dual_scan_list if dual * ecutwfc < self.ctx.max_ecutrho]:
+        for ecutrho in [dual * ecutwfc for dual in self.ctx.dual_scan_list]:
             ecutwfc, ecutrho = round(ecutwfc), round(ecutrho)
+            # TODO check and assert that ecutrho should not exceed max_ecutrho
             inputs = self._get_inputs(ecutwfc=ecutwfc, ecutrho=ecutrho)
 
             running = self.submit(self._EVALUATE_WORKCHAIN, **inputs)

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -90,6 +90,8 @@ class VerificationWorkChain(WorkChain):
         spec.input('properties_list', valid_type=orm.List,
                     default=lambda: orm.List(list=DEFAULT_PROPERTIES_LIST),
                     help='The preperties will be calculated, passed as a list.')
+        spec.input('preset_ecutwfc', valid_type=orm.Int, required=False,
+                    help='Preset wavefunction cutoff will be used and skip wavefunction test.')
         spec.input('options', valid_type=orm.Dict, required=False,
                     help='Optional `options`')
         spec.input('parallelization', valid_type=orm.Dict, required=False,
@@ -190,6 +192,8 @@ class VerificationWorkChain(WorkChain):
 
         base_conv_inputs = base_inputs.copy()
         base_conv_inputs["criteria"] = self.inputs.criteria
+        if "preset_ecutwfc" in self.inputs:
+            base_conv_inputs["preset_ecutwfc"] = self.inputs.preset_ecutwfc
 
         # Properties list
         valid_list = self._VALID_ACCURACY_WF + self._VALID_CONGENCENCE_WF

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -26,7 +26,6 @@ def run_verification(pw_code, ph_code, upf, properties_list=DEFAULT_PROPERTIES_L
         "protocol": orm.Str("test"),
         "criteria": orm.Str("efficiency"),
         "cutoff_control": orm.Str("test"),
-        "preset_ecutwfc": orm.Int(34),
         "properties_list": orm.List(list=properties_list),
         "options": orm.Dict(
             dict={

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -26,6 +26,7 @@ def run_verification(pw_code, ph_code, upf, properties_list=DEFAULT_PROPERTIES_L
         "protocol": orm.Str("test"),
         "criteria": orm.Str("efficiency"),
         "cutoff_control": orm.Str("test"),
+        "preset_ecutwfc": orm.Int(34),
         "properties_list": orm.List(list=properties_list),
         "options": orm.Dict(
             dict={


### PR DESCRIPTION
Setting `preset_check` for convergence workflow will skip wavefunction cutoff test and only process the rho test.
This is useful for branching the tests for different criteria. When running either convergence test on `efficiency` or `precision` criteria, the wfc test is the same. This step will write recommended cutoff of all criteria to the output. 
When rerun the convergence test the `preset_check` can be used to run on that cutoff for rho cutoff test only.