### PR TITLE
atomic npool parallelization set to 1

### DIFF
--- a/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -150,7 +150,9 @@ class ConvergenceCohesiveEnergyWorkChain(_BaseConvergenceWorkChain):
 
         # atomic parallelization always set npool to 1 since only one kpoints
         # requires no k parallel
-        atomic_parallelization = update_dict({"npool": 1}, self.ctx.parallelization)
+        atomic_parallelization = self.ctx.parallelization.copy()
+        atomic_parallelization.pop("npool", None)
+        atomic_parallelization = update_dict(atomic_parallelization, {"npool": 1})
 
         # atom_parameters update with ecutwfc and ecutrho
         atom_parameters = self.ctx.atom_parameters.copy()

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -47,13 +47,13 @@ def run_verification(
             dict={
                 "resources": {
                     "num_machines": 1,
-                    "num_mpiprocs_per_machine": 1,
+                    "num_mpiprocs_per_machine": 2,
                 },
                 "max_wallclock_seconds": 1800 * 3,
                 "withmpi": True,
             }
         ),
-        "parallelization": orm.Dict(dict={}),
+        "parallelization": orm.Dict(dict={"npool": 2}),
         "clean_workdir_level": orm.Int(clean_level),
     }
 


### PR DESCRIPTION
fixes #130 

The update_dict will override the `{"npool": 1}` if the second parameter has the npool set. 
Here I remove the npool set if it is exist and update the dict explictly.