### PR TITLE
bands calculation for bands distance using symmetry reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ merge eigenvalues (sorted) of the same kpoints.
 
 There are three kinds of kpoint distance (`kpoints_distance_scf`, `kpoints_distance_bands` and `kpoints_distance_band_strcuture` respectively) for bands measure workflow and two for bands distance convergence workflow where the band structure is not calculated in convergence verification.
 
-In the production protocol, the `kpoints_distance_bands` is set to `0.25` which is not so dense as scf calculation since in the bands nscf calculation the symmetry is not applied (as discussed following.) which lead to the calculation very time consuming if the number of kpoints are enourmous.
-
+In the production protocol, the `kpoints_distance_bands` is set to `0.1`.
 We choose a uniform k-grid for bands distance comparison,
-in the full Brillouin zone and with no symmetry reduction.
+in the full Brillouin zone and with symmetry reduction which not implemented in previous version.
+After applying symmetry reduction, it is able to compute with more dense grids.
 Because, choosing a high-symmetry path could result in an unsatisfactory arbitrary choice,
 as different recipes for the standardisation of paths have been introduced in the recent literature and interesting features of the band structure may occur far from the high-symmetry lines (such as Weyl points).
 A uniform mesh is also more appropriate from the point of view of electron’s nearsightedness
 if the energy eigenvalues are known on a sufficiently fine uniform k-points mesh,
-it is possible to get an exact real-space representation of the Hamiltonian in a Wannier function basis32 and then interpolate to an arbitrary fine mesh.
+it is possible to get an exact real-space representation of the Hamiltonian in a Wannier function basis and then interpolate to an arbitrary fine mesh.
 
 ## Parameters of protocol
 

--- a/aiida_sssp_workflow/calculations/calculate_bands_distance.py
+++ b/aiida_sssp_workflow/calculations/calculate_bands_distance.py
@@ -71,6 +71,7 @@ def retrieve_bands(
         nelectrons = num_electrons
         bands = np.asfortranarray(bands)
         meth = 2  # firmi-dirac smearing
+        print(sum(weights), nelectrons)
 
         output_efermi = find_efermi(bands, weights, nelectrons, smearing, meth)
         print(output_efermi)
@@ -128,8 +129,8 @@ def calculate_eta_and_max_diff(
 
     def fun_shift(occ, bands_diff, shift):
         # import ipdb; ipdb.set_trace()
-        nominator = np.multiply(weight[:, None], (occ * (bands_diff + shift) ** 2))
-        denominator = np.multiply(weight[:, None], occ)
+        nominator = np.multiply(1 / weight[:, None], (occ * (bands_diff + shift) ** 2))
+        denominator = np.multiply(1 / weight[:, None], occ)
         return np.sqrt(np.sum(nominator) / np.sum(denominator))
 
     # Compute eta

--- a/aiida_sssp_workflow/calculations/calculate_bands_distance.py
+++ b/aiida_sssp_workflow/calculations/calculate_bands_distance.py
@@ -71,10 +71,8 @@ def retrieve_bands(
         nelectrons = num_electrons
         bands = np.asfortranarray(bands)
         meth = 2  # firmi-dirac smearing
-        print(sum(weights), nelectrons)
 
         output_efermi = find_efermi(bands, weights, nelectrons, smearing, meth)
-        print(output_efermi)
 
     else:
         # easy to spot the efermi energy only used for non-metals of typical configurations
@@ -97,7 +95,7 @@ def calculate_eta_and_max_diff(
     smearing,
 ):
     """
-    docstring
+    calculate the difference of two bands, weight is supported
     """
     from functools import partial
 
@@ -128,7 +126,7 @@ def calculate_eta_and_max_diff(
     bands_diff = bands_a - bands_b
 
     def fun_shift(occ, bands_diff, shift):
-        # import ipdb; ipdb.set_trace()
+        # 1/w ~ degeneracy of the kpoints
         nominator = np.multiply(1 / weight[:, None], (occ * (bands_diff + shift) ** 2))
         denominator = np.multiply(1 / weight[:, None], occ)
         return np.sqrt(np.sum(nominator) / np.sum(denominator))
@@ -165,7 +163,7 @@ def get_bands_distance(
     do_smearing: bool,
 ):
     """
-    TODO docstring
+    First aligh the number of two bands, e.g tranctrate the overceed nubmer of bands
     """
     num_electrons_a = band_parameters_a["number_of_electrons"]
     num_electrons_b = band_parameters_b["number_of_electrons"]
@@ -196,7 +194,6 @@ def get_bands_distance(
     else:
         smearing_v = 0
 
-    # import ipdb; ipdb.set_trace()
     outputs = calculate_eta_and_max_diff(
         bands_a, bands_b, efermi_a, efermi_b, fermi_shift_v, smearing_v
     )

--- a/aiida_sssp_workflow/calculations/calculate_bands_distance.py
+++ b/aiida_sssp_workflow/calculations/calculate_bands_distance.py
@@ -50,6 +50,7 @@ def retrieve_bands(
     I simply concatenate along the first dimension.
     """
     bands = bandsdata.get_bands()
+    kpoints, weights = bandsdata.get_kpoints(also_weights=True)
 
     # reduce by first dimension of up, down spins
     if len(bands.shape) > 2:
@@ -60,19 +61,19 @@ def retrieve_bands(
     bands = bands - efermi  # shift all bands to fermi energy 0
     bands = bands[:, start_band:]
     output_bands = orm.ArrayData()
-    output_bands.set_array("kpoints", bandsdata.get_kpoints())
+    output_bands.set_array("kpoints", kpoints)
+    output_bands.set_array("weights", weights)
     output_bands.set_array("bands", bands)
 
     if do_smearing:
         # for bands distance convergence
         # and metals in bands measure verification.
         nelectrons = num_electrons
-        nkpoints = np.shape(bands)[0]
-        weights = np.ones(nkpoints) / nkpoints
         bands = np.asfortranarray(bands)
         meth = 2  # firmi-dirac smearing
 
         output_efermi = find_efermi(bands, weights, nelectrons, smearing, meth)
+        print(output_efermi)
 
     else:
         # easy to spot the efermi energy only used for non-metals of typical configurations
@@ -101,8 +102,16 @@ def calculate_eta_and_max_diff(
 
     from scipy.optimize import minimize
 
+    weight_a = bands_a.get_array("weights")
+    weight_b = bands_b.get_array("weights")
+    weight = weight_a
+    assert np.allclose(
+        weight_a, weight_b
+    ), "Different weight of kpoints of two calculation."
+
     bands_a = bands_a.get_array("bands")
     bands_b = bands_b.get_array("bands")
+
     num_bands = min(np.shape(bands_a)[1], np.shape(bands_b)[1])
 
     assert np.shape(bands_a)[0] == np.shape(bands_b)[0], "have different kpoints"
@@ -118,7 +127,10 @@ def calculate_eta_and_max_diff(
     bands_diff = bands_a - bands_b
 
     def fun_shift(occ, bands_diff, shift):
-        return np.sqrt(np.sum(occ * (bands_diff + shift) ** 2) / np.sum(occ))
+        # import ipdb; ipdb.set_trace()
+        nominator = np.multiply(weight[:, None], (occ * (bands_diff + shift) ** 2))
+        denominator = np.multiply(weight[:, None], occ)
+        return np.sqrt(np.sum(nominator) / np.sum(denominator))
 
     # Compute eta
     eta_val = partial(fun_shift, occ, bands_diff)
@@ -156,34 +168,25 @@ def get_bands_distance(
     """
     num_electrons_a = band_parameters_a["number_of_electrons"]
     num_electrons_b = band_parameters_b["number_of_electrons"]
+
+    assert (
+        not num_electrons_a > num_electrons_b
+    ), "Need to be less num_electrons result as argument labeled 'a'."
+
     efermi_a = band_parameters_a["fermi_energy"]
     efermi_b = band_parameters_b["fermi_energy"]
 
-    if num_electrons_a <= num_electrons_b:
-        num_electrons = int(num_electrons_a)
-        res = retrieve_bands(bands_a, 0, num_electrons, efermi_a, smearing, do_smearing)
-        bands_a = res["bands"]
-        efermi_a = res["efermi"]
+    num_electrons = int(num_electrons_a)
+    res = retrieve_bands(bands_a, 0, num_electrons, efermi_a, smearing, do_smearing)
+    bands_a = res["bands"]
+    efermi_a = res["efermi"]
 
-        start_band = int(num_electrons_b - num_electrons_a) // 2
-        res = retrieve_bands(
-            bands_b, start_band, num_electrons, efermi_b, smearing, do_smearing
-        )
-        bands_b = res["bands"]
-        efermi_b = res["efermi"]
-    else:
-        # num_electrons_b < num_electrons_a:
-        num_electrons = int(num_electrons_b)
-        start_band = int(num_electrons_a - num_electrons_b) // 2
-        res = retrieve_bands(
-            bands_a, start_band, num_electrons, efermi_a, smearing, do_smearing
-        )
-        bands_a = res["bands"]
-        efermi_a = res["efermi"]
-
-        res = retrieve_bands(bands_b, 0, num_electrons, efermi_b, smearing, do_smearing)
-        bands_b = res["bands"]
-        efermi_b = res["efermi"]
+    start_band = int(num_electrons_b - num_electrons_a) // 2
+    res = retrieve_bands(
+        bands_b, start_band, num_electrons, efermi_b, smearing, do_smearing
+    )
+    bands_b = res["bands"]
+    efermi_b = res["efermi"]
 
     # eta_v
     fermi_shift_v = 0.0
@@ -192,6 +195,7 @@ def get_bands_distance(
     else:
         smearing_v = 0
 
+    # import ipdb; ipdb.set_trace()
     outputs = calculate_eta_and_max_diff(
         bands_a, bands_b, efermi_a, efermi_b, fermi_shift_v, smearing_v
     )

--- a/aiida_sssp_workflow/efermi.py
+++ b/aiida_sssp_workflow/efermi.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 Reuse the pure python translate from Nicola's F77 code
-Copy and paste from Austin's repository:
+Adapt from Austin's repository:
 https://github.com/zooks97/bieFermi/tree/main/bieFermi/py
 """
 

--- a/aiida_sssp_workflow/protocol/bands.yml
+++ b/aiida_sssp_workflow/protocol/bands.yml
@@ -8,7 +8,7 @@ acwf:
     smearing: fd
     electron_conv_thr: 1.0e-10
     kpoints_distance_scf: 0.10
-    kpoints_distance_bands: 0.25
+    kpoints_distance_bands: 0.10
     kpoints_distance_band_structure: 0.10
 
     init_nbands_factor: 3

--- a/aiida_sssp_workflow/protocol/converge.yml
+++ b/aiida_sssp_workflow/protocol/converge.yml
@@ -28,7 +28,7 @@ acwf:
         init_nbands_factor: 3.0
         fermi_shift: 10.0
         kpoints_distance_scf: 0.15
-        kpoints_distance_bands: 0.25
+        kpoints_distance_bands: 0.10
 
     delta:
         scale_count: 7
@@ -61,7 +61,7 @@ test:
 
     bands:
         init_nbands_factor: 3.0
-        fermi_shift: 5.0
+        fermi_shift: 10.0
         kpoints_distance_scf: 0.5
         kpoints_distance_bands: 0.25
 

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -115,8 +115,6 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
         parameters = update_dict(parameters, self.ctx.pw_parameters)
 
         parameters_bands = parameters.copy()
-        # parameters_bands["SYSTEM"]["nosym"] = True    # TODO:
-        # parameters_bands["SYSTEM"]["noinv"] = True    # TODO:
         parameters_bands["SYSTEM"].pop("nbnd", None)
 
         inputs = {

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -115,7 +115,8 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
         parameters = update_dict(parameters, self.ctx.pw_parameters)
 
         parameters_bands = parameters.copy()
-        parameters_bands["SYSTEM"]["nosym"] = True    # TODO:
+        # parameters_bands["SYSTEM"]["nosym"] = True    # TODO:
+        # parameters_bands["SYSTEM"]["noinv"] = True    # TODO:
         parameters_bands["SYSTEM"].pop("nbnd", None)
 
         inputs = {

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -17,20 +17,29 @@ UpfData = DataFactory("pseudo.upf")
 
 @calcfunction
 def helper_bands_distence_difference(
-    bands_structure_a: orm.BandsData,
-    bands_parameters_a: orm.Dict,
-    bands_structure_b: orm.BandsData,
-    bands_parameters_b: orm.Dict,
+    band_structure_a: orm.BandsData,
+    band_parameters_a: orm.Dict,
+    band_structure_b: orm.BandsData,
+    band_parameters_b: orm.Dict,
     smearing: orm.Float,
     fermi_shift: orm.Float,
     do_smearing: orm.Bool,
 ):
     """doc"""
+    # `get_bands_distance` require the less electrons results pass
+    # to inputs of label 'a', do swap a and b if not.
+    num_electrons_a = band_parameters_a["number_of_electrons"]
+    num_electrons_b = band_parameters_b["number_of_electrons"]
+
+    if num_electrons_a > num_electrons_b:
+        band_parameters_a, band_parameters_b = band_parameters_b, band_parameters_a
+        band_structure_a, band_structure_b = band_structure_b, band_structure_a
+
     res = get_bands_distance(
-        bands_structure_a,
-        bands_structure_b,
-        bands_parameters_a,
-        bands_parameters_b,
+        band_structure_a,
+        band_structure_b,
+        band_parameters_a,
+        band_parameters_b,
         smearing.value,
         fermi_shift.value,
         do_smearing.value,
@@ -146,18 +155,18 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
 
     def helper_compare_result_extract_fun(self, sample_node, reference_node, **kwargs):
         """implement"""
-        sample_bands_output = sample_node.outputs["bands"].band_parameters
-        reference_bands_output = reference_node.outputs["bands"].band_parameters
+        sample_band_parameters = sample_node.outputs["bands"].band_parameters
+        reference_band_parameters = reference_node.outputs["bands"].band_parameters
 
-        sample_bands_structure = sample_node.outputs["bands"].band_structure
-        reference_bands_structure = reference_node.outputs["bands"].band_structure
+        sample_band_structure = sample_node.outputs["bands"].band_structure
+        reference_band_structure = reference_node.outputs["bands"].band_structure
 
         # Always process smearing to find fermi level even for non-metal elements.
         res = helper_bands_distence_difference(
-            sample_bands_structure,
-            sample_bands_output,
-            reference_bands_structure,
-            reference_bands_output,
+            sample_band_structure,
+            sample_band_parameters,
+            reference_band_structure,
+            reference_band_parameters,
             smearing=orm.Float(self.ctx.degauss * self._RY_TO_EV),
             fermi_shift=orm.Float(self.ctx.fermi_shift),
             do_smearing=orm.Bool(True),


### PR DESCRIPTION
Fixes #97 

The weights of bands were not used for bands distance calculation, leading to not being able to use symmetry restriction in bands nscf calculation. 
This limit the kpoints mesh of nscf calculation can't be dense enough. 
This PR implements the weights for bands distance calculation and remove `nosym=True` from input.