### PR TITLE
reintrospect clean policy to avoid too many inode on remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ In case of atomic calculation running on a machine with too many CPUs,
 the `npool` and `ndiag` is explicitly set to 1 for atomic calculation.
 Since there is only one kpoint in atomic case, there is no efficient lost of this parallelization setting.
 
+Because using too many `mpiprocs` (128 in EIGER) in atomic calculation would cause spurious issue the calculation terminate and not being handled.
+The maximum number of mpiprocs is set to `32`.
+
 ### Walltime settings
 
 The max wallclock seconds are set from the `options` input parameters from verification workflow.
@@ -121,6 +124,17 @@ The lanthanides still using the nitrides from Wenzovitch paper.
 We keep on using typical nature configuration from Cottiner's paper, but convert them to primitive with pymatgen (for magnetic elements, no primitive convert process but still refine with `pymatgen`).
 Maybe the flourine (F) still have thekproblem mentioned in legacy SSSP that hard to convergence (SCF convergence), will rollback to use SiF4 for it.
 
+## Work chains clean policy
+
+It is very delegate of how to set the remote folder clean in pseudopotential verification, since the verification consist of workflows with lots of sub processes and create huge amount of remote files, although the single calculations are small and resource non-stringent.
+If the work chains are not cleaned, the number of remote files will increase rapidly and disk quota in remote machine will soon being run out.
+But if clean too early would make caching machanism not used and therefore waste resource for same calculations.
+To trait off above to controdiction, the clean policy is:
+- set to the accuracy measures are cleaned right after its workchain are finished, the clean also include remove the node to be used for further caching.
+- set `_caching` work chain to be cleaned only by calling from verefication work chain rather than do itself. For other convergence work chain, they used nodes cached from `_caching` workchain and will clean them self right after it is finished. The nodes from convergence work chain never used for furthur caching except for testing mode.
+
+The clean policy of big verification work chain is controlled by `test_mode`.
+It will do clean as described above or do not clean anything so it can be checked afterwards.
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,17 @@ Maybe the flourine (F) still have thekproblem mentioned in legacy SSSP that hard
 
 It is very delegate of how to set the remote folder clean in pseudopotential verification, since the verification consist of workflows with lots of sub processes and create huge amount of remote files, although the single calculations are small and resource non-stringent.
 If the work chains are not cleaned, the number of remote files will increase rapidly and disk quota in remote machine will soon being run out.
-But if clean too early would make caching machanism not used and therefore waste resource for same calculations.
-To trait off above to controdiction, the clean policy is:
-- set to the accuracy measures are cleaned right after its workchain are finished, the clean also include remove the node to be used for further caching.
-- set `_caching` work chain to be cleaned only by calling from verefication work chain rather than do itself. For other convergence work chain, they used nodes cached from `_caching` workchain and will clean them self right after it is finished. The nodes from convergence work chain never used for furthur caching except for testing mode.
+On the contrast, if clean too early would make caching machanism not used and therefore waste resource for same calculations.
+To trait off above two side of contradiction, the clean policy is designed as:
+- set to the accuracy measures are cleaned right after its workchain are finished.
+- set calcjob nodes of `_caching` work chain to be cleaned only by calling from verefication work chain in its terminate step rather than do itself.
+For other convergence work chain, they used nodes cached from `_caching` workchain and will clean themself right after it is finished.
+The nodes create from other cached nodes (which have `_aiida_cached_from` extra attributes) from convergence work chain never used for furthur caching except for testing mode.
+
+This partially solve the caching issue of bands calculation ([issue #138](https://github.com/aiidateam/aiida-sssp-workflow/issues/138).
+But same as ph.x calculation, is subsequent step failed and previous step cleaned, it will still failed to continue.
+In phonon, the workaround is to check if the remote folder is empty.
+This has the expense of even the ph.x calculation finished ok, the previous step clean will force the scf prepare calculation to run again so to sure the ph.x get its parent_folder not empty.
 
 The clean policy of big verification work chain is controlled by `test_mode`.
 It will do clean as described above or do not clean anything so it can be checked afterwards.

--- a/aiida_sssp_workflow/workflows/__init__.py
+++ b/aiida_sssp_workflow/workflows/__init__.py
@@ -1,6 +1,8 @@
 from aiida.engine import WorkChain
 from aiida.orm import Bool, CalcJobNode
 
+from aiida_sssp_workflow.workflows.common import clean_workdir
+
 
 class SelfCleanWorkChain(WorkChain):
     @classmethod
@@ -9,27 +11,28 @@ class SelfCleanWorkChain(WorkChain):
         spec.input(
             "clean_workdir",
             valid_type=Bool,
-            default=lambda: Bool(False),
+            default=lambda: Bool(True),
             help="If `True`, work directories of all called calculation will be cleaned at the end of execution.",
         )
 
     def on_terminated(self):
-        """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs."""
+        """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs.
+        If clean, important to also invalid calcjob nodes for caching. Since otherwise there will be chance
+        that not the caching node but cleaned node used for caching in bands and phonon that will lead to the
+        parent_folder empty issue.
+        In big verification workflow, only _caching workflow is not process clean step at last but purge remote
+        folder after the whole verfication workflow finished.
+        hardcode the invalid_caching.
+        """
         super().on_terminated()
 
         if self.inputs.clean_workdir.value is False:
-            self.report("remote folders will not be cleaned")
+            self.report(f"{type(self)}: remote folders will not be cleaned")
             return
 
-        cleaned_calcs = []
-
-        for called_descendant in self.node.called_descendants:
-            if isinstance(called_descendant, CalcJobNode):
-                try:
-                    called_descendant.outputs.remote_folder._clean()  # pylint: disable=protected-access
-                    cleaned_calcs.append(called_descendant.pk)
-                except (IOError, OSError, KeyError):
-                    pass
+        cleaned_calcs = clean_workdir(
+            self.node, all_same_nodes=False, invalid_caching=True
+        )
 
         if cleaned_calcs:
             self.report(

--- a/aiida_sssp_workflow/workflows/common.py
+++ b/aiida_sssp_workflow/workflows/common.py
@@ -1,5 +1,6 @@
 import importlib
 
+from aiida import orm
 from aiida.plugins import DataFactory
 
 from pseudo_parser.upf_parser import parse_element, parse_pseudo_type
@@ -63,3 +64,57 @@ def get_pseudo_O():
         pseudo_O = UpfData(stream)
 
     return pseudo_O
+
+
+def clean_workdir(wfnode, all_same_nodes=False, invalid_caching=True):
+    """clean the remote folder of all calculation in the workchain node
+    return the node pk of cleaned calculation.
+
+    :param wfnode: workflow node to clean its descendat calcjob nodes
+    :param all_same_nodes: If `True`, fetch all same node and process the clean. BE CAREFUL!
+    :param invalid_caching: If `True`, disable caching the calcjob cleaned, so ph, bands
+        not failed because of cleaned node is used as parent scf calculation.
+    :return: return the list of nodes pk being cleaned
+    """
+
+    def clean(node: orm.CalcJobNode, _invalid_caching=True):
+        """clean node workdir"""
+        node.outputs.remote_folder._clean()  # pylint: disable=protected-access
+        if (
+            _invalid_caching
+            and "_aiida_cached_from" in node.extras
+            and "_aiida_hash" in node.extras
+        ):
+            # It is implemented in aiida 2.0.0, by setting the is_valid_cache.
+            # set the it to disable the caching to precisely control extras.
+            # here in order that the correct node is cleaned and caching controlled
+            # I only invalid_caching if this node is cached from other node, otherwise
+            # that node (should be the node from `_caching` workflow) will not be invalid
+            # caching.
+            # This ensure that if the calcjob is identically running, it will still be used for
+            # further calculation.
+            node.delete_extra("_aiida_hash")
+
+        return node.pk
+
+    cleaned_calcs = []
+    for descendant_node in wfnode.called_descendants:
+        if isinstance(descendant_node, orm.CalcJobNode):
+            same_nodes = descendant_node.get_all_same_nodes()
+            try:
+                if all_same_nodes:
+                    # clean all same nodes
+                    for n in same_nodes:
+                        calc_pk = clean(n, invalid_caching)
+                        cleaned_calcs.append(calc_pk)
+                else:
+                    # clean only this node
+                    calc_pk = clean(descendant_node, invalid_caching)
+                    cleaned_calcs.append(calc_pk)
+
+            except (IOError, OSError, KeyError) as exc:
+                raise RuntimeError(
+                    "Failed to clean working dirctory of calcjob"
+                ) from exc
+
+    return cleaned_calcs

--- a/aiida_sssp_workflow/workflows/convergence/_base.py
+++ b/aiida_sssp_workflow/workflows/convergence/_base.py
@@ -287,9 +287,8 @@ class _BaseConvergenceWorkChain(SelfCleanWorkChain):
                 'conv_thr': conv_thr,
             },
             'CONTROL': {
-                'calculation': 'scf',
-                'wf_collect': True,
-                'tstress': True,
+                # 'calculation': 'scf', NOT EXPLICITLY SET. `scf` is default if not override.
+                'tstress': True,    # for pressue to use _caching node directly.
             },
         }
 

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -116,6 +116,7 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
 
         parameters_bands = parameters.copy()
         parameters_bands["SYSTEM"].pop("nbnd", None)
+        parameters_bands["CONTROL"].pop("tstress", None)
 
         inputs = {
             "structure": self.ctx.structure,

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -114,7 +114,7 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
 
         parameters = update_dict(parameters, self.ctx.pw_parameters)
 
-        parameters_bands = parameters.copy()
+        parameters_bands = update_dict(parameters, {})
         parameters_bands["SYSTEM"].pop("nbnd", None)
         parameters_bands["CONTROL"].pop("tstress", None)
 

--- a/aiida_sssp_workflow/workflows/convergence/caching.py
+++ b/aiida_sssp_workflow/workflows/convergence/caching.py
@@ -1,6 +1,7 @@
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 
+from aiida_sssp_workflow.utils import update_dict
 from aiida_sssp_workflow.workflows.convergence._base import _BaseConvergenceWorkChain
 
 PwBaseWorkflow = WorkflowFactory("quantumespresso.pw.base")
@@ -73,7 +74,7 @@ class _CachingConvergenceWorkChain(_BaseConvergenceWorkChain):
 
     def _get_inputs(self, ecutwfc, ecutrho) -> dict:
         """inputs for running a dummy SCF for caching"""
-        pw_parameters = self.ctx.pw_base_parameters.copy()
+        pw_parameters = update_dict(self.ctx.pw_base_parameters, {})
         pw_parameters["SYSTEM"]["ecutwfc"] = ecutwfc
         pw_parameters["SYSTEM"]["ecutrho"] = ecutrho
 

--- a/aiida_sssp_workflow/workflows/convergence/caching.py
+++ b/aiida_sssp_workflow/workflows/convergence/caching.py
@@ -23,6 +23,16 @@ class _CachingConvergenceWorkChain(_BaseConvergenceWorkChain):
     _RUN_WFC_TEST = True
     _RUN_RHO_TEST = False  # will not run charge density cutoff test
 
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+        spec.input(
+            "clean_workdir",
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
+            help="If `True`, work directories of all called calculation will be cleaned at the end of execution.",
+        )
+
     def inspect_wfc_convergence_test(self):
         """Override this step to do nothing to parse wavefunction
         cutoff test results but only run it."""

--- a/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -150,21 +150,21 @@ class ConvergenceCohesiveEnergyWorkChain(_BaseConvergenceWorkChain):
 
         # atomic parallelization always set npool to 1 since only one kpoints
         # requires no k parallel
-        atomic_parallelization = self.ctx.parallelization.copy()
+        atomic_parallelization = update_dict(self.ctx.parallelization, {})
         atomic_parallelization.pop("npool", None)
         atomic_parallelization.pop("ndiag", None)
         atomic_parallelization = update_dict(atomic_parallelization, {"npool": 1})
         atomic_parallelization = update_dict(atomic_parallelization, {"ndiag": 1})
 
         # atomic option if mpiprocs too many confine it too no larger than 32 procs
-        atomic_options = self.ctx.options.copy()
+        atomic_options = update_dict(self.ctx.options, {})
         if atomic_options["resources"]["num_mpiprocs_per_machine"] > 32:
             # copy is a shallow copy, so using update_dict.
             # if simply assign the value will change also the original dict
             atomic_options = update_dict(atomic_options, {"resources": {"num_mpiprocs_per_machine": 32}})
 
         # atom_parameters update with ecutwfc and ecutrho
-        atom_parameters = self.ctx.atom_parameters.copy()
+        atom_parameters = update_dict(self.ctx.atom_parameters, {})
         for element in atom_parameters.keys():
             atom_parameters[element] = update_dict(atom_parameters[element], update_parameters)
 

--- a/aiida_sssp_workflow/workflows/convergence/delta.py
+++ b/aiida_sssp_workflow/workflows/convergence/delta.py
@@ -95,6 +95,9 @@ class ConvergenceDeltaWorkChain(_BaseConvergenceWorkChain):
             },
         }
         parameters = update_dict(parameters, self.ctx.pw_parameters)
+        parameters["CONTROL"].pop(
+            "tstress", None
+        )  # this will rule this work chain out from caching
 
         inputs = {
             "eos": {

--- a/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
@@ -179,7 +179,7 @@ class ConvergencePhononFrequenciesWorkChain(_BaseConvergenceWorkChain):
 
         # Sinec PH calculation always runs more time then the correspoding pw calculation
         # set the walltime to 4 times as set in option.
-        ph_options = self.ctx.options.copy()
+        ph_options = update_dict(self.ctx.options, {})
         pw_max_walltime = self.ctx.options.get("max_wallclock_seconds", None)
         if pw_max_walltime:
             ph_options["max_wallclock_seconds"] = pw_max_walltime * 4

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -174,6 +174,7 @@ class ConvergencePressureWorkChain(_BaseConvergenceWorkChain):
             },
         }
         parameters = update_dict(parameters, self.ctx.pw_parameters)
+        parameters["CONTROL"].pop("tstress", None)
 
         inputs = {
             "metadata": {"call_link_label": "pressure_ref_EOS"},

--- a/aiida_sssp_workflow/workflows/measure/bands.py
+++ b/aiida_sssp_workflow/workflows/measure/bands.py
@@ -185,8 +185,7 @@ class BandsMeasureWorkChain(_BaseMeasureWorkChain):
         }
         parameters = update_dict(parameters, self.ctx.pw_parameters)
 
-        parameters_bands = parameters.copy()
-        parameters_bands["SYSTEM"]["nosym"] = True    # TODO: to be removed
+        parameters_bands = update_dict(parameters, {})
         parameters_bands["SYSTEM"].pop("nbnd", None)
 
         inputs = {

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -3,7 +3,6 @@
 All in one verification workchain
 """
 # pylint: disable=cyclic-import
-from copy import deepcopy
 
 from aiida import orm
 from aiida.engine import ToContext, WorkChain, if_
@@ -193,8 +192,8 @@ class VerificationWorkChain(WorkChain):
             accurary_inputs["clean_workdir"] = orm.Bool(False)
 
         self.ctx.accuracy_inputs = {
-            "delta": deepcopy(accurary_inputs),
-            "bands": deepcopy(accurary_inputs),
+            "delta": accurary_inputs.copy(),
+            "bands": accurary_inputs.copy(),
         }
 
         # Convergence inputs setting, the properties of convergence test are:
@@ -212,22 +211,22 @@ class VerificationWorkChain(WorkChain):
         convergence_inputs["parallelization"] = self.inputs.parallelization
 
         if self.inputs.test_mode:
-            accurary_inputs["clean_workdir"] = orm.Bool(False)
+            convergence_inputs["clean_workdir"] = orm.Bool(False)
 
-        inputs_phonon_frequencies = deepcopy(convergence_inputs)
+        inputs_phonon_frequencies = convergence_inputs.copy()
         inputs_phonon_frequencies.pop("code", None)
         inputs_phonon_frequencies["pw_code"] = self.inputs.pw_code
         inputs_phonon_frequencies["ph_code"] = self.inputs.ph_code
 
         self.ctx.convergence_inputs = {
-            "cohesive_energy": deepcopy(convergence_inputs),
+            "cohesive_energy": convergence_inputs.copy(),
             "phonon_frequencies": inputs_phonon_frequencies,
-            "pressure": deepcopy(convergence_inputs),
-            "delta": deepcopy(convergence_inputs),
+            "pressure": convergence_inputs.copy(),
+            "delta": convergence_inputs.copy(),
             "bands": convergence_inputs.copy(),
         }
 
-        self.ctx.caching_inputs = deepcopy(convergence_inputs)
+        self.ctx.caching_inputs = convergence_inputs.copy()
         self.ctx.caching_inputs["clean_workdir"] = orm.Bool(
             False
         )  # shouldn't clean until last

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -213,6 +213,9 @@ class VerificationWorkChain(WorkChain):
         if self.inputs.test_mode:
             convergence_inputs["clean_workdir"] = orm.Bool(False)
 
+        # Here, the shallow copy can be used since the type of convergence_inputs
+        # is AttributesDict.
+        # The deepcopy can't be used, since it will create new data node.
         inputs_phonon_frequencies = convergence_inputs.copy()
         inputs_phonon_frequencies.pop("code", None)
         inputs_phonon_frequencies["pw_code"] = self.inputs.pw_code

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -3,13 +3,15 @@
 All in one verification workchain
 """
 # pylint: disable=cyclic-import
+from copy import deepcopy
+
 from aiida import orm
-from aiida.engine import WorkChain, if_
+from aiida.engine import ToContext, WorkChain, if_
 from aiida.engine.processes.exit_code import ExitCode
 from aiida.engine.processes.functions import calcfunction
 from aiida.plugins import DataFactory, WorkflowFactory
-from plumpy import ToContext
 
+from aiida_sssp_workflow.workflows.common import clean_workdir
 from aiida_sssp_workflow.workflows.convergence import _BaseConvergenceWorkChain
 from aiida_sssp_workflow.workflows.convergence.caching import (
     _CachingConvergenceWorkChain,
@@ -90,11 +92,8 @@ class VerificationWorkChain(WorkChain):
                     help='Optional `options`')
         spec.input('parallelization', valid_type=orm.Dict, required=False,
                     help='Parallelization options')
-        spec.input('clean_workdir_level', valid_type=orm.Int, default=lambda: orm.Int(1),
-                    help='0 for not clean; '
-                    '1 for precheck clean finished ok workchain except bands related wf; '
-                    '2 for standard clean all finished ok workchains, but phonon will depend; '
-                    '9 for clean all.')
+        spec.input('test_mode', valid_type=orm.Bool, default=lambda: orm.Bool(False),
+                    help='If `True`, do not clean workdir of any step.')
 
         spec.outline(
             cls.setup_code_resource_options,
@@ -190,9 +189,12 @@ class VerificationWorkChain(WorkChain):
         accurary_inputs["options"] = self.inputs.options
         accurary_inputs["parallelization"] = self.inputs.parallelization
 
+        if self.inputs.test_mode:
+            accurary_inputs["clean_workdir"] = orm.Bool(False)
+
         self.ctx.accuracy_inputs = {
-            "delta": accurary_inputs.copy(),
-            "bands": accurary_inputs.copy(),
+            "delta": deepcopy(accurary_inputs),
+            "bands": deepcopy(accurary_inputs),
         }
 
         # Convergence inputs setting, the properties of convergence test are:
@@ -209,20 +211,26 @@ class VerificationWorkChain(WorkChain):
         convergence_inputs["options"] = self.inputs.options
         convergence_inputs["parallelization"] = self.inputs.parallelization
 
-        inputs_phonon_frequencies = convergence_inputs.copy()
+        if self.inputs.test_mode:
+            accurary_inputs["clean_workdir"] = orm.Bool(False)
+
+        inputs_phonon_frequencies = deepcopy(convergence_inputs)
         inputs_phonon_frequencies.pop("code", None)
         inputs_phonon_frequencies["pw_code"] = self.inputs.pw_code
         inputs_phonon_frequencies["ph_code"] = self.inputs.ph_code
 
         self.ctx.convergence_inputs = {
-            "cohesive_energy": convergence_inputs.copy(),
+            "cohesive_energy": deepcopy(convergence_inputs),
             "phonon_frequencies": inputs_phonon_frequencies,
-            "pressure": convergence_inputs.copy(),
-            "delta": convergence_inputs.copy(),
+            "pressure": deepcopy(convergence_inputs),
+            "delta": deepcopy(convergence_inputs),
             "bands": convergence_inputs.copy(),
         }
 
-        self.ctx.caching_inputs = convergence_inputs.copy()
+        self.ctx.caching_inputs = deepcopy(convergence_inputs)
+        self.ctx.caching_inputs["clean_workdir"] = orm.Bool(
+            False
+        )  # shouldn't clean until last
 
         # to collect workchains in a dict
         self.ctx.workchains = {}
@@ -359,116 +367,16 @@ class VerificationWorkChain(WorkChain):
         """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs."""
         super().on_terminated()
 
-        clean_workdir_level = self.inputs.clean_workdir_level.value
-        if clean_workdir_level == 9:
-            # extermination all all!!
-            cleaned_calcs = self._clean_workdir(self.node)
+        if self.inputs.test_mode.value:
+            # Do not clean anything
+            self.report("In test mode: no remote folders will not be cleaned.")
+            return
+        else:
+            cleaned_calcs = clean_workdir(
+                self.node, all_same_nodes=True, invalid_caching=True
+            )
 
             if cleaned_calcs:
                 self.report(
                     f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}"
                 )
-
-        elif clean_workdir_level == 1:
-            skip_workchains = [
-                "convergence.phonon_frequencies",
-                "accuracy.bands",
-                "convergence.bands",
-            ]
-            for wname, pk in self.ctx.finished_ok_wf.items():
-                if wname not in skip_workchains:
-                    node = orm.load_node(pk)
-                    cleaned_calcs = self._clean_workdir(node)
-
-                    self.report(
-                        f"These workchains are skipped to clean: {skip_workchains}"
-                    )
-
-                    for k, calcs in cleaned_calcs.items():
-                        self.report(
-                            f"cleaned remote folders of calculations {k} "
-                            f"[belong to finished_ok work chain {wname}]: {' '.join(map(str, calcs))}"
-                        )
-
-        elif clean_workdir_level == 2:
-            # only clean finished ok work chain
-
-            for wname, pk in self.ctx.finished_ok_wf.items():
-                if wname not in ["convergence.phonon_frequencies"]:
-                    node = orm.load_node(pk)
-                    cleaned_calcs = self._clean_workdir(node)
-
-                    for k, calcs in cleaned_calcs.items():
-                        self.report(
-                            f"cleaned remote folders of calculations {k} "
-                            f"[belong to finished_ok work chain {wname}]: {' '.join(map(str, calcs))}"
-                        )
-
-            # clean the caching workdir only when phonon_frequencies sub-workflow is finished_ok
-            phonon_convergence_workchain = self.ctx.workchains.get(
-                "convergence.phonon_frequencies", None
-            )
-            if (
-                phonon_convergence_workchain
-                and phonon_convergence_workchain.is_finished_ok
-            ):
-                try:
-                    caching_workchain = self.ctx.verify_caching
-                    cleaned_calcs = self._clean_workdir(caching_workchain)
-
-                    for k, calcs in cleaned_calcs.items():
-                        self.report(
-                            f"cleaned remote folders of calculations {k} "
-                            f"[belong to finished_ok work chain _caching]: {' '.join(map(str, calcs))}"
-                        )
-                except AttributeError:
-                    # caching not run
-                    self.logger.warning("Caching is not running will not clean it.")
-
-            else:
-                self.logger.warning(
-                    "Convergence verification of phonon frequecies not run, don't clean caching."
-                )
-
-        else:
-            # clean level = 0
-            self.report("remote folders will not be cleaned")
-            return
-
-    @staticmethod
-    def _clean_workdir(wfnode, include_caching=True):
-        """clean the remote folder of all calculation in the workchain node
-        return the node pk of cleaned calculation.
-        """
-
-        def clean(node: orm.CalcJobNode):
-            """clean node workdir"""
-            cleaned_calcs_lst = []
-            node.outputs.remote_folder._clean()  # pylint: disable=protected-access
-            cleaned_calcs_lst.append(called_descendant.pk)
-
-            return cleaned_calcs_lst
-
-        cleaned_calcs = {}
-        for called_descendant in wfnode.called_descendants:
-            if isinstance(called_descendant, orm.CalcJobNode):
-                try:
-                    calcs = clean(called_descendant)
-                    cleaned_calcs[
-                        "menon"
-                    ] = calcs  # menon for noumenon for not cached but real one
-
-                    # clean caching node
-                    if include_caching:
-                        caching_nodes = called_descendant.get_all_same_nodes()
-                        if len(caching_nodes) > 1:  # since it always contain the menon
-                            for node in caching_nodes:
-                                cached_calcs = clean(node)
-                                cleaned_calcs["cached"] = cached_calcs
-
-                except (IOError, OSError, KeyError) as exc:
-                    raise RuntimeError(
-                        "Failed to clean working dirctory of calcjob"
-                    ) from exc
-
-        return cleaned_calcs

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -366,7 +366,7 @@ class VerificationWorkChain(WorkChain):
             )
 
     def on_terminated(self):
-        """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs."""
+        """Clean the working directories of all child calculations if `test_mode=True` in the inputs."""
         super().on_terminated()
 
         if self.inputs.test_mode.value:

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -21,12 +21,10 @@ STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_static")
 def run_verification(
     pw_code, ph_code, upf, properties_list=DEFAULT_PROPERTIES_LIST, label=None
 ):
-    # if phonon, not clean, since empty remote folder will always trigger rerun.
-    if "convergence.phonon_frequencies" in properties_list:
-        clean_level = 0
+    if properties_list == DEFAULT_PROPERTIES_LIST:
+        test_mode = False
     else:
-        clean_level = 1
-
+        test_mode = True
     inputs = {
         "accuracy": {
             "protocol": orm.Str("test"),
@@ -54,7 +52,7 @@ def run_verification(
             }
         ),
         "parallelization": orm.Dict(dict={"npool": 2}),
-        "clean_workdir_level": orm.Int(1),
+        "test_mode": orm.Bool(test_mode),
     }
 
     res, node = run_get_node(VerificationWorkChain, **inputs)


### PR DESCRIPTION
fixes #144 

It is very delegate of how to set the remote folder clean in pseudopotential verification, since the verification consist of workflows with lots of sub processes and create huge amount of remote files, although the single calculations are small and resource non-stringent.
If the work chains are not cleaned, the number of remote files will increase rapidly and disk quota in remote machine will soon being run out.
On the contrast, if clean too early would make caching machanism not used and therefore waste resource for same calculations.
To trait off above two side of contradiction, the clean policy is designed as:
- set to the accuracy measures are cleaned right after its workchain are finished.
- set calcjob nodes of `_caching` work chain to be cleaned only by calling from verefication work chain in its terminate step rather than do itself.
For other convergence work chain, they used nodes cached from `_caching` workchain and will clean themself right after it is finished.
The nodes create from other cached nodes (which have `_aiida_cached_from` extra attributes) from convergence work chain never used for furthur caching except for testing mode.

This partially solve the caching issue of bands calculation ([issue #138](https://github.com/aiidateam/aiida-sssp-workflow/issues/138).
But same as ph.x calculation, is subsequent step failed and previous step cleaned, it will still failed to continue.
In phonon, the workaround is to check if the remote folder is empty.
This has the expense of even the ph.x calculation finished ok, the previous step clean will force the scf prepare calculation to run again so to sure the ph.x get its parent_folder not empty.

The clean policy of big verification work chain is controlled by `test_mode`.
It will do clean as described above or do not clean anything so it can be checked afterwards.

PR include two major change. 
1. The clean policy as described above
2. using `update_dict` as deepcopy for all dict copy in workflow but not the `AttributesDict` which is exposed_inputs and will clone the data nodes that is not the expected behaviour.