### PR TITLE
Propagate clean_workchain to evaluation workchain

### DIFF
--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -149,6 +149,7 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
             "run_bands_structure": orm.Bool(
                 False
             ),  # for convergence with no band structure evaluate
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -197,6 +197,7 @@ class ConvergenceCohesiveEnergyWorkChain(_BaseConvergenceWorkChain):
                 },
                 "kpoints": atom_kpoints,
             },
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/convergence/delta.py
+++ b/aiida_sssp_workflow/workflows/convergence/delta.py
@@ -118,6 +118,7 @@ class ConvergenceDeltaWorkChain(_BaseConvergenceWorkChain):
             },
             "element": orm.Str(self.ctx.element),
             "configuration": orm.Str(self.ctx.configuration),
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
@@ -210,7 +210,8 @@ class ConvergencePhononFrequenciesWorkChain(_BaseConvergenceWorkChain):
                     },
                     "settings": orm.Dict(dict={"CMDLINE": cmdline_list}),
                 },
-            }
+            },
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/convergence/pressure.py
+++ b/aiida_sssp_workflow/workflows/convergence/pressure.py
@@ -150,6 +150,7 @@ class ConvergencePressureWorkChain(_BaseConvergenceWorkChain):
                 "parallelization": orm.Dict(dict=self.ctx.parallelization),
             },
             "kpoints_distance": orm.Float(self.ctx.kpoints_distance),
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/measure/bands.py
+++ b/aiida_sssp_workflow/workflows/measure/bands.py
@@ -218,6 +218,7 @@ class BandsMeasureWorkChain(_BaseMeasureWorkChain):
             "fermi_shift": orm.Float(self.ctx.fermi_shift),
             "run_bands_structure": orm.Bool(True),
             "kpoints_distance_band_structure": orm.Float(self.ctx.kpoints_distance_band_structure),
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/measure/delta.py
+++ b/aiida_sssp_workflow/workflows/measure/delta.py
@@ -284,6 +284,7 @@ class DeltaMeasureWorkChain(_BaseMeasureWorkChain):
             },
             "element": orm.Str(self.ctx.element),
             "configuration": orm.Str(configuration),
+            "clean_workchain": self.inputs.clean_workchain,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -76,9 +76,9 @@ class VerificationWorkChain(SelfCleanWorkChain):
         super().define(spec)
         # yapf: disable
         spec.expose_inputs(_BaseMeasureWorkChain, namespace='accuracy',
-                    exclude=['code', 'pseudo', 'options', 'parallelization'])
+                    exclude=['code', 'pseudo', 'options', 'parallelization', 'clean_workchain'])
         spec.expose_inputs(_BaseConvergenceWorkChain, namespace='convergence',
-                    exclude=['code', 'pseudo', 'options', 'parallelization'])
+                    exclude=['code', 'pseudo', 'options', 'parallelization', 'clean_workchain'])
         spec.input('pw_code', valid_type=orm.Code,
                     help='The `pw.x` code use for the `PwCalculation`.')
         spec.input('ph_code', valid_type=orm.Code,

--- a/examples/example_verification.py
+++ b/examples/example_verification.py
@@ -51,8 +51,8 @@ def run_verification(
                 "withmpi": True,
             }
         ),
-        "parallelization": orm.Dict(dict={"npool": 2}),
-        "clean_workchain": orm.Bool(True),
+        "parallelization": orm.Dict(dict={"npool": 1}),
+        "clean_workchain": orm.Bool(clean_workchain),
     }
 
     res, node = run_get_node(VerificationWorkChain, **inputs)


### PR DESCRIPTION
The evaluate workchains of every properties are also all inherit from `SelfCleanWorkChain`
to to the remote workdir clean after single evaluation step is done.
This immediate clean will keep remote machine quato avaliable with many
verification at the same time.
However, the `clean_workchain` flag setting from parent workchain which
calls the evaluate workchain are not properly propagate this parameter
to evaluate workchain, lead to that evaluate workchain always get
cleaned as default.