### PR TITLE
Increase kpoints distance and using tetrahedro for EOS of all delta calculation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For lanthanides the delta measure is run on nitrides as Wentzcovitch paper and o
 The unaries are not run for delta since it is know that the oxidation state of lanthanides pseudopotentials is not zero.
 Only for lanthanide nitrides the magnatization is on.
 It is mostly because the reference of RE-N (Wentzcovitch) and RE-O (ACWF) is run with/without magnatization.
-The kpoint distance of lanthanide nitrides is hard code to `0.2` (implemented as `+ 0.1` from acwf value) using the tetrahedron method rather than as acwf protocol where kpoint distance is `0.10` with fermi-dirac smearing, in order to compatible with Wentzcovitch paper results.
+The kpoint distance of lanthanide nitrides is hard code to `0.2` (both for accuracy delta measure, for delta convergence and first EOS reference calculation of pressure convergence test as well. implemented as `+ 0.1` of accuracy protocol and `+ 0.05` of convergence protocol from acwf value) using the tetrahedron method rather than as acwf protocol where kpoint distance is `0.10` with fermi-dirac smearing, in order to compatible with Wentzcovitch paper results.
 Lanthanide nitrides such as ErN, in equation of state calculation, large (0.06) volume change lead to supurious energy.
 To mitigate the issue, the `scale_increment` is set to 0.01 (??? probably only for Er?) to make sure the volume change is in the parabolic range.
 The nitrogen pseudopotential is the one from first run on pseudopotentials verifications on nitrigen on libraries include Pslibrary 0.1, Pslibrary 1.0.0, pseudo-dojo, ONCVPSP with legacy sg15 inputs... (Run and check)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For lanthanides the delta measure is run on nitrides as Wentzcovitch paper and o
 The unaries are not run for delta since it is know that the oxidation state of lanthanides pseudopotentials is not zero.
 Only for lanthanide nitrides the magnatization is on.
 It is mostly because the reference of RE-N (Wentzcovitch) and RE-O (ACWF) is run with/without magnatization.
-The kpoint distance of lanthanide nitrides is hard code to `0.2` using the tetrahedron method rather than as acwf protocol where kpoint distance is `0.10` with fermi-dirac smearing, in order to compatible with Wentzcovitch paper results.
+The kpoint distance of lanthanide nitrides is hard code to `0.2` (implemented as `+ 0.1` from acwf value) using the tetrahedron method rather than as acwf protocol where kpoint distance is `0.10` with fermi-dirac smearing, in order to compatible with Wentzcovitch paper results.
 Lanthanide nitrides such as ErN, in equation of state calculation, large (0.06) volume change lead to supurious energy.
 To mitigate the issue, the `scale_increment` is set to 0.01 (??? probably only for Er?) to make sure the volume change is in the parabolic range.
 The nitrogen pseudopotential is the one from first run on pseudopotentials verifications on nitrigen on libraries include Pslibrary 0.1, Pslibrary 1.0.0, pseudo-dojo, ONCVPSP with legacy sg15 inputs... (Run and check)

--- a/aiida_sssp_workflow/workflows/convergence/delta.py
+++ b/aiida_sssp_workflow/workflows/convergence/delta.py
@@ -99,6 +99,13 @@ class ConvergenceDeltaWorkChain(_BaseConvergenceWorkChain):
             "tstress", None
         )  # this will rule this work chain out from caching
 
+        # sparse kpoints and tetrahedra occupation in EOS reference calculation
+        if self.ctx.element in RARE_EARTH_ELEMENTS:
+            self.ctx.kpoints_distance = self._KDISTANCE + 0.05
+            parameters["SYSTEM"].pop("smearing", None)
+            parameters["SYSTEM"].pop("degauss", None)
+            parameters["SYSTEM"]["occupations"] = "tetrahedra"
+
         inputs = {
             "eos": {
                 "metadata": {"call_link_label": "delta_EOS"},

--- a/aiida_sssp_workflow/workflows/evaluate/_eos.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_eos.py
@@ -88,6 +88,7 @@ class _EquationOfStateWorkChain(WorkChain):
         inputs["pw"]["structure"] = scale_structure(
             self.inputs.structure, orm.Float(scale_factor)
         )
+        inputs.pop("kpoints_distance", None)
 
         return inputs
 


### PR DESCRIPTION
fixes #164 

Also fix the issue that in the pw base workchain of eos, both `kpoints` and `kpoints_distance` are set. Although it causes no issue yet, it will potentially lead to bugs.