### PR TITLE
Record a list of invalid caching node and bring it back

### DIFF
--- a/aiida_sssp_workflow/workflows/__init__.py
+++ b/aiida_sssp_workflow/workflows/__init__.py
@@ -1,11 +1,7 @@
 from aiida.engine import WorkChain
 from aiida.orm import Bool, CalcJobNode
 
-from aiida_sssp_workflow.workflows.common import (
-    clean_workdir,
-    invalid_cache,
-    operate_calcjobs,
-)
+from aiida_sssp_workflow.workflows.common import clean_workdir, operate_calcjobs
 
 
 class SelfCleanWorkChain(WorkChain):

--- a/aiida_sssp_workflow/workflows/__init__.py
+++ b/aiida_sssp_workflow/workflows/__init__.py
@@ -27,7 +27,7 @@ class SelfCleanWorkChain(WorkChain):
         """
         super().on_terminated()
 
-        if self.inputs.clean_workdir.value is False:
+        if not self.inputs.clean_workdir.value:
             self.report(f"{type(self)}: remote folders will not be cleaned")
             return
 

--- a/aiida_sssp_workflow/workflows/common.py
+++ b/aiida_sssp_workflow/workflows/common.py
@@ -101,14 +101,14 @@ def operate_calcjobs(wnode, operator, all_same_nodes=False):
     """
 
     cleaned_calcs = []
-    for descendant_node in wnode.called_descendants:
-        if isinstance(descendant_node, orm.CalcJobNode):
+    for child in wnode.called_descendants:
+        if isinstance(child, orm.CalcJobNode):
             # the nodes waid for operated.
-            nodes = descendant_node.get_all_same_nodes()
+            nodes = child.get_all_same_nodes()
             try:
                 if not all_same_nodes:
                     # only operated on this node
-                    nodes = [descendant_node]
+                    nodes = [child]
 
                 for n in nodes:
                     pk = operator(n)

--- a/aiida_sssp_workflow/workflows/convergence/bands.py
+++ b/aiida_sssp_workflow/workflows/convergence/bands.py
@@ -159,6 +159,7 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
                     },
                     "parallelization": orm.Dict(dict=self.ctx.parallelization),
                 },
+                "clean_workdir": self.inputs.clean_workdir,
             },
             "kpoints_distance_bands": orm.Float(self.ctx.kpoints_distance_bands),
             "init_nbands_factor": orm.Float(self.ctx.init_nbands_factor),
@@ -166,7 +167,8 @@ class ConvergenceBandsWorkChain(_BaseConvergenceWorkChain):
             "run_bands_structure": orm.Bool(
                 False
             ),  # for convergence with no band structure evaluate
-            "clean_workdir": self.inputs.clean_workdir,
+            # Don't clean workdir for bands calculation, since it will race condition with the phonon workchain.
+            # "clean_workdir": self.inputs.clean_workdir,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/convergence/delta.py
+++ b/aiida_sssp_workflow/workflows/convergence/delta.py
@@ -135,7 +135,7 @@ class ConvergenceDeltaWorkChain(_BaseConvergenceWorkChain):
             },
             "element": orm.Str(self.ctx.element),
             "configuration": orm.Str(self.ctx.configuration),
-            "clean_workdir": self.inputs.clean_workdir,  # should already cleaned by eos, here for safe
+            # "clean_workdir": self.inputs.clean_workdir,  # should already cleaned by eos, here for safe
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/convergence/phonon_frequencies.py
@@ -214,8 +214,10 @@ class ConvergencePhononFrequenciesWorkChain(_BaseConvergenceWorkChain):
                     },
                     "settings": orm.Dict(dict={"CMDLINE": cmdline_list}),
                 },
+                "clean_workdir": self.inputs.clean_workdir,
             },
-            "clean_workdir": self.inputs.clean_workdir,
+            # Don't clean phonon workchain workdir, since it race condition with the bands workchain
+            # "clean_workdir": self.inputs.clean_workdir,
         }
 
         return inputs

--- a/aiida_sssp_workflow/workflows/evaluate/__init__.py
+++ b/aiida_sssp_workflow/workflows/evaluate/__init__.py
@@ -26,3 +26,13 @@ class _BaseEvaluateWorkChain(SelfCleanWorkChain):
         They are needed by the convergence workflow to read the cutoff pair
         of evalueation.
         """
+
+    def _disable_cache(self, workchain):
+        # I do not want SCF calc used for caching if it is a from cached
+        # calculation
+        for child in workchain.called_descendants:
+            if (
+                child.process_label == "PwCalculation"
+                and child.base.caching.is_created_from_cache
+            ):
+                child.is_valid_cache = False

--- a/aiida_sssp_workflow/workflows/evaluate/_bands.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_bands.py
@@ -159,6 +159,8 @@ class BandsWorkChain(_BaseEvaluateWorkChain):
 
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_BANDS
 
+        self._disable_cache(workchain)
+
         self.ctx.ecutwfc = workchain.inputs.scf.pw.parameters["SYSTEM"]["ecutwfc"]
         self.ctx.ecutrho = workchain.inputs.scf.pw.parameters["SYSTEM"]["ecutrho"]
 

--- a/aiida_sssp_workflow/workflows/evaluate/_cohesive_energy.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_cohesive_energy.py
@@ -147,6 +147,8 @@ class CohesiveEnergyWorkChain(_BaseEvaluateWorkChain):
             )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_BULK_ENERGY
 
+        self._disable_cache(workchain_bulk_energy)
+
         self.ctx.bulk_energy = workchain_bulk_energy.outputs.output_parameters["energy"]
         calc_time = workchain_bulk_energy.outputs.output_parameters["wall_time_seconds"]
 

--- a/aiida_sssp_workflow/workflows/evaluate/_eos.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_eos.py
@@ -37,7 +37,7 @@ class _EquationOfStateWorkChain(WorkChain):
         spec.input('scale_increment', valid_type=orm.Float, default=lambda: orm.Float(0.02),
             help='The relative difference between consecutive scaling factors.')
         spec.expose_inputs(PwBaseWorkChain,
-            exclude=('kpoints', 'pw.structure', 'pw.kpoints_distance', 'clean_workdir'),
+            exclude=('kpoints', 'pw.structure', 'pw.kpoints_distance'),
             namespace_options={'help': 'Inputs for the `PwBaseWorkChain` for the SCF calculation.'})
         spec.outline(
             cls.run_init,

--- a/aiida_sssp_workflow/workflows/evaluate/_phonon_frequencies.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_phonon_frequencies.py
@@ -80,6 +80,8 @@ class PhononFrequenciesWorkChain(_BaseEvaluateWorkChain):
 
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_SCF
 
+        self._disable_cache(workchain)
+
         try:
             remote_folder = self.ctx.scf_remote_folder = workchain.outputs.remote_folder
 

--- a/aiida_sssp_workflow/workflows/evaluate/_pressure.py
+++ b/aiida_sssp_workflow/workflows/evaluate/_pressure.py
@@ -71,6 +71,8 @@ class PressureWorkChain(_BaseEvaluateWorkChain):
             )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_SCF
 
+        self._disable_cache(workchain)
+
         output_trajectory = workchain.outputs.output_trajectory
         output_parameters = workchain.outputs.output_parameters
 

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -36,13 +36,21 @@ def parse_pseudo_info(pseudo: UpfData):
     return orm.Dict(dict=info)
 
 
-DEFAULT_CONVERGENCE_PROPERTIES_LIST = [
-    "convergence.cohesive_energy",
+_REMOTE_FOLDER_DEPENDENT_CONVERENCE_PROPERTIES_LIST = [
+    "convergence.bands",
     "convergence.phonon_frequencies",
+]
+
+_REMOTE_FOLDER_INDEPENDENT_CONVERGENCE_PROPERTIES_LIST = [
+    "convergence.cohesive_energy",
     "convergence.pressure",
     "convergence.delta",
-    "convergence.bands",
 ]
+
+DEFAULT_CONVERGENCE_PROPERTIES_LIST = (
+    _REMOTE_FOLDER_DEPENDENT_CONVERENCE_PROPERTIES_LIST
+    + _REMOTE_FOLDER_INDEPENDENT_CONVERGENCE_PROPERTIES_LIST
+)
 
 DEFAULT_MEASURE_PROPERTIES_LIST = [
     "measure.precision",
@@ -99,17 +107,18 @@ class VerificationWorkChain(SelfCleanWorkChain):
             cls.setup_code_resource_options,
             cls.parse_pseudo,
             cls.init_setup,
-            if_(cls.is_verify_measure)(
-                cls.run_measure,
-                cls.inspect_measure,
-            ),
             if_(cls.is_verify_convergence)(
                 if_(cls.is_caching)(
                     cls.run_caching,
                     cls.inspect_caching,
                 ),
-                cls.run_convergence,
+                cls.run_remote_folder_dependent_convergence,
+                cls.run_remote_folder_independent_convergence,
                 cls.inspect_convergence,
+            ),
+            if_(cls.is_verify_measure)(
+                cls.run_measure,
+                cls.inspect_measure,
             ),
         )
         spec.output('pseudo_info', valid_type=orm.Dict, required=True,
@@ -251,31 +260,6 @@ class VerificationWorkChain(SelfCleanWorkChain):
         # For store the finished_ok workflow
         self.ctx.finished_ok_wf = {}
 
-    def is_verify_measure(self):
-        """
-        Whether to run measure (delta measure, bands distance} workflow.
-        """
-        for p in self.ctx.properties_list:
-            if "measure" in p:
-                return True
-
-        return False
-
-    def run_measure(self):
-        """Run delta measure sub-workflow"""
-        for property in DEFAULT_MEASURE_PROPERTIES_LIST:
-            property_name = property.split(".")[1]
-            if property in self.ctx.properties_list:
-                MeasureWorkflow = WorkflowFactory(f"sssp_workflow.{property}")
-
-                running = self.submit(
-                    MeasureWorkflow, **self.ctx["measure_inputs"][property_name]
-                )
-                self.report(f"Submit {property_name} measure workchain pk={running.pk}")
-
-                self.to_context(_=running)
-                self.ctx.workchains[f"{property}"] = running
-
     def inspect_measure(self):
         """Inspect delta measure results"""
         return self._report_and_results(wname_list=self._VALID_MEASURE_WF)
@@ -318,13 +302,10 @@ class VerificationWorkChain(SelfCleanWorkChain):
         if not workchain.is_finished_ok:
             return self.exit_codes.ERROR_CACHING_ON_BUT_FAILED
 
-    def run_convergence(self):
-        """
-        running all verification workflows
-        """
-        for property in DEFAULT_CONVERGENCE_PROPERTIES_LIST:
+    def _run_convergence(self, plist):
+        for property in self.ctx.properties_list:
             property_name = property.split(".")[1]
-            if property in self.ctx.properties_list:
+            if property in plist:
                 ConvergenceWorkflow = WorkflowFactory(f"sssp_workflow.{property}")
 
                 running = self.submit(
@@ -337,6 +318,18 @@ class VerificationWorkChain(SelfCleanWorkChain):
                 self.to_context(_=running)
                 self.ctx.workchains[f"{property}"] = running
 
+    def run_remote_folder_dependent_convergence(self):
+        """
+        running convergence workflow that requires remote_folder not cleaned, e.g. phonon_frequencies, bands
+        """
+        self._run_convergence(_REMOTE_FOLDER_DEPENDENT_CONVERENCE_PROPERTIES_LIST)
+
+    def run_remote_folder_independent_convergence(self):
+        """
+        running convergence workflow that requires remote_folder not cleaned, e.g. phonon_frequencies, bands
+        """
+        self._run_convergence(_REMOTE_FOLDER_INDEPENDENT_CONVERGENCE_PROPERTIES_LIST)
+
     def inspect_convergence(self):
         """
         inspect the convergence result
@@ -344,6 +337,31 @@ class VerificationWorkChain(SelfCleanWorkChain):
         the list set the avaliable convergence workchain that will be inspected
         """
         return self._report_and_results(wname_list=self._VALID_CONGENCENCE_WF)
+
+    def is_verify_measure(self):
+        """
+        Whether to run measure (delta measure, bands distance} workflow.
+        """
+        for p in self.ctx.properties_list:
+            if "measure" in p:
+                return True
+
+        return False
+
+    def run_measure(self):
+        """Run delta measure sub-workflow"""
+        for property in DEFAULT_MEASURE_PROPERTIES_LIST:
+            property_name = property.split(".")[1]
+            if property in self.ctx.properties_list:
+                MeasureWorkflow = WorkflowFactory(f"sssp_workflow.{property}")
+
+                running = self.submit(
+                    MeasureWorkflow, **self.ctx["measure_inputs"][property_name]
+                )
+                self.report(f"Submit {property_name} measure workchain pk={running.pk}")
+
+                self.to_context(_=running)
+                self.ctx.workchains[f"{property}"] = running
 
     def _report_and_results(self, wname_list):
         """result to respective output namespace"""

--- a/aiida_sssp_workflow/workflows/verifications.py
+++ b/aiida_sssp_workflow/workflows/verifications.py
@@ -389,6 +389,5 @@ class VerificationWorkChain(SelfCleanWorkChain):
     def on_terminated(self):
         super().on_terminated()
 
-        if self.inputs.clean_workdir.value is False:
+        if not self.inputs.clean_workdir.value:
             self.report(f"{type(self)}: remote folders will not be cleaned")
-            return


### PR DESCRIPTION
fixes #205 

1. Record a list of invalid caching node and bring it back when the new  calculaiton is run.
2. Separate convergence properties to bands/phonon_frequencies (remote folder dependent workflows) and delta/cohesive/pressure (remote folder independent workflows).