### PR TITLE
revised number of rows in eos precision plot

### DIFF
--- a/src/aiida_sssp_workflow/cli/inspect.py
+++ b/src/aiida_sssp_workflow/cli/inspect.py
@@ -5,6 +5,7 @@
 import json
 import random
 from pathlib import Path
+from math import ceil
 
 import click
 import matplotlib.pyplot as plt
@@ -333,7 +334,7 @@ def inspect(node, output):
                 pass
 
             # if there are 5 plots, need 3 rows, since the output_parametres is in the dict len(precision) / 2 is the number of rows
-            rows = len(precision) // 2
+            rows = ceil(len(results) / 2)
 
             # create a figure with 2 columns and rows rows on a a4 size paper
             fig, axs = plt.subplots(rows, 2, figsize=(8.27, 11.69), dpi=100)

--- a/src/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
+++ b/src/aiida_sssp_workflow/workflows/convergence/cohesive_energy.py
@@ -189,7 +189,7 @@ def compute_xy(
 
     reference_node = orm.load_node(report.reference.uuid)
     output_parameters_r: orm.Dict = reference_node.outputs.output_parameters
-    y_ref = output_parameters_r['cohesive_energy_per_atom']
+    y_ref = output_parameters_r["cohesive_energy_per_atom"]
 
     xs = []
     ys = []
@@ -198,24 +198,25 @@ def compute_xy(
         if node_point.exit_status != 0:
             # TODO: log to a warning file for where the node is not finished_okay
             continue
-        
+
         x = node_point.wavefunction_cutoff
         xs.append(x)
 
         node = orm.load_node(node_point.uuid)
         output_parameters_p: orm.Dict = node.outputs.output_parameters
 
-        y = (output_parameters_p['cohesive_energy_per_atom'] - y_ref) / y_ref * 100
+        y = (output_parameters_p["cohesive_energy_per_atom"] - y_ref) / y_ref * 100
         ys.append(y)
-        ys_cohesive_energy_per_atom.append(output_parameters_p['cohesive_energy_per_atom'])
+        ys_cohesive_energy_per_atom.append(
+            output_parameters_p["cohesive_energy_per_atom"]
+        )
 
     return {
-        'xs': xs,
-        'ys': ys,
-        'ys_relative_diff': ys,
-        'ys_cohesive_energy_per_atom': ys_cohesive_energy_per_atom,
-        'metadata': {
-            'unit': '%',
-        }
+        "xs": xs,
+        "ys": ys,
+        "ys_relative_diff": ys,
+        "ys_cohesive_energy_per_atom": ys_cohesive_energy_per_atom,
+        "metadata": {
+            "unit": "%",
+        },
     }
-

--- a/src/aiida_sssp_workflow/workflows/transferability/eos.py
+++ b/src/aiida_sssp_workflow/workflows/transferability/eos.py
@@ -472,7 +472,9 @@ def extract_eos(
             continue
 
         raw_eos[k] = point_node.outputs.eos.output_volume_energy.get_dict()
-        birch_murnaghan_fit[k] = point_node.outputs.eos.output_birch_murnaghan_fit.get_dict()
+        birch_murnaghan_fit[k] = (
+            point_node.outputs.eos.output_birch_murnaghan_fit.get_dict()
+        )
         metric_dict[k] = point_node.outputs.output_parameters.get_dict()
 
     return raw_eos, birch_murnaghan_fit, metric_dict


### PR DESCRIPTION
a small bug
the result of rows = len(precision) // 2 is 2 rather than 3 when len(precision) = 5