### PR TITLE
Using cold smearing for convergence test

### DIFF
--- a/src/aiida_sssp_workflow/protocol/convergence.yml
+++ b/src/aiida_sssp_workflow/protocol/convergence.yml
@@ -6,7 +6,7 @@ balanced:
     base:   # base parameters is inherit by other process
         occupations: smearing
         degauss: 0.02   # balanced protocol of qe -> gabriel
-        smearing: fd
+        smearing: cold
         conv_thr_per_atom: 1.0e-8
         kpoints_distance: 0.2  # balanced protocol of qe -> gabriel
         mixing_beta: 0.4


### PR DESCRIPTION
For the balanced protocol, the smearing width is 0.02 and it is supposed to be used with cold smearing. The fermi-dirac smearing requires a smaller width such as 0.0045 used in EOS calculations of transferibility workflows.